### PR TITLE
load models programmatically

### DIFF
--- a/llms/providers/base_provider.py
+++ b/llms/providers/base_provider.py
@@ -7,8 +7,12 @@ class BaseProvider:
     Methods will raise NotImplementedError if they are not overwritten.
     """
 
-    def __init__(self):
+    MODEL_INFO = {}
+
+    def __init__(self, model=None, api_key=None, **kwargs):
         self.latency = None
+        # to be overwritten by subclasses
+        self.api_key = api_key
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__} ({self.model})"

--- a/llms/providers/google.py
+++ b/llms/providers/google.py
@@ -21,7 +21,7 @@ class GoogleProvider(BaseProvider):
         },
     }
 
-    def __init__(self, model=None):
+    def __init__(self, model=None, **kwargs):
         if model is None:
             model = list(self.MODEL_INFO.keys())[0]
 
@@ -29,7 +29,7 @@ class GoogleProvider(BaseProvider):
 
         self.client = ChatModel.from_pretrained(model)
 
-        vertexai.init()
+        vertexai.init(**kwargs)
 
     def _prepare_model_input(
         self,


### PR DESCRIPTION
should be easier to maintain, and lets me pass custom parameters like:
`model = llms.init("chat-bison", project=config["GOOGLE_PROJECT"], location=config["GOOGLE_ZONE"])`
this lets me store Application Default Credentials for a new isolated project, while keeping my default project in gcloud CLI unchanged, set to my main project, which doesn't have Vertex API enabled, in order to isolate projects and their costs.