### PR TITLE
feat: add api_base parameter to providers for custom base URL

### DIFF
--- a/llms/providers/deepseek.py
+++ b/llms/providers/deepseek.py
@@ -14,22 +14,26 @@ class DeepSeekProvider(BaseProvider):
         "deepseek-reasoner": {"prompt": 0.55, "completion": 2.19, "token_limit": 32768, "is_chat": True, "output_limit": 8192},
     }
 
+    DEFAULT_BASE_URL = "https://api.deepseek.com/v1"
+
     def __init__(
         self,
         api_key: Union[str, None] = None,
         model: Union[str, None] = None,
+        api_base: Union[str, None] = None,
         client_kwargs: Union[dict, None] = None,
         async_client_kwargs: Union[dict, None] = None,
     ):
         if model is None:
             model = list(self.MODEL_INFO.keys())[0]
         self.model = model
+        base_url = api_base or self.DEFAULT_BASE_URL
         if client_kwargs is None:
             client_kwargs = {}
-        self.client = OpenAI(api_key=api_key, base_url="https://api.deepseek.com/v1", **client_kwargs)
+        self.client = OpenAI(api_key=api_key, base_url=base_url, **client_kwargs)
         if async_client_kwargs is None:
             async_client_kwargs = {}
-        self.async_client = AsyncOpenAI(api_key=api_key, base_url="https://api.deepseek.com/v1", **async_client_kwargs)
+        self.async_client = AsyncOpenAI(api_key=api_key, base_url=base_url, **async_client_kwargs)
 
     @property
     def is_chat_model(self) -> bool:

--- a/llms/providers/groq.py
+++ b/llms/providers/groq.py
@@ -19,22 +19,26 @@ class GroqProvider(BaseProvider):
         "meta-llama/llama-4-scout-17b-16e-instruct": {"prompt": 0.11, "completion": 0.34, "token_limit": 131072, "is_chat": True},
     }
 
+    DEFAULT_BASE_URL = "https://api.groq.com/openai/v1"
+
     def __init__(
         self,
         api_key: Union[str, None] = None,
         model: Union[str, None] = None,
+        api_base: Union[str, None] = None,
         client_kwargs: Union[dict, None] = None,
         async_client_kwargs: Union[dict, None] = None,
     ):
         if model is None:
             model = list(self.MODEL_INFO.keys())[0]
         self.model = model
+        base_url = api_base or self.DEFAULT_BASE_URL
         if client_kwargs is None:
             client_kwargs = {}
-        self.client = OpenAI(api_key=api_key, base_url="https://api.groq.com/openai/v1", **client_kwargs)
+        self.client = OpenAI(api_key=api_key, base_url=base_url, **client_kwargs)
         if async_client_kwargs is None:
             async_client_kwargs = {}
-        self.async_client = AsyncOpenAI(api_key=api_key, base_url="https://api.groq.com/openai/v1", **async_client_kwargs)
+        self.async_client = AsyncOpenAI(api_key=api_key, base_url=base_url, **async_client_kwargs)
 
     @property
     def is_chat_model(self) -> bool:

--- a/llms/providers/openai.py
+++ b/llms/providers/openai.py
@@ -37,6 +37,7 @@ class OpenAIProvider(BaseProvider):
         self,
         api_key: Union[str, None] = None,
         model: Union[str, None] = None,
+        api_base: Union[str, None] = None,
         client_kwargs: Union[dict, None] = None,
         async_client_kwargs: Union[dict, None] = None,
     ):
@@ -45,9 +46,13 @@ class OpenAIProvider(BaseProvider):
         self.model = model
         if client_kwargs is None:
             client_kwargs = {}
+        if api_base:
+            client_kwargs.setdefault('base_url', api_base)
         self.client = OpenAI(api_key=api_key, **client_kwargs)
         if async_client_kwargs is None:
             async_client_kwargs = {}
+        if api_base:
+            async_client_kwargs.setdefault('base_url', api_base)
         self.async_client = AsyncOpenAI(api_key=api_key, **async_client_kwargs)
 
     @property

--- a/llms/providers/openrouter.py
+++ b/llms/providers/openrouter.py
@@ -30,22 +30,26 @@ class OpenRouterProvider(BaseProvider):
         },
     }
 
+    DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+
     def __init__(
         self,
         api_key: Union[str, None] = None,
         model: Union[str, None] = None,
+        api_base: Union[str, None] = None,
         client_kwargs: Union[dict, None] = None,
         async_client_kwargs: Union[dict, None] = None,
     ):
         if model is None:
             model = list(self.MODEL_INFO.keys())[0]
         self.model = model
+        base_url = api_base or self.DEFAULT_BASE_URL
         if client_kwargs is None:
             client_kwargs = {}
-        self.client = OpenAI(api_key=api_key, base_url="https://openrouter.ai/api/v1", **client_kwargs)
+        self.client = OpenAI(api_key=api_key, base_url=base_url, **client_kwargs)
         if async_client_kwargs is None:
             async_client_kwargs = {}
-        self.async_client = AsyncOpenAI(api_key=api_key, base_url="https://openrouter.ai/api/v1", **async_client_kwargs)
+        self.async_client = AsyncOpenAI(api_key=api_key, base_url=base_url, **async_client_kwargs)
 
     @property
     def is_chat_model(self) -> bool:

--- a/tests/test_custom_api_base.py
+++ b/tests/test_custom_api_base.py
@@ -1,0 +1,101 @@
+"""
+Tests for custom api_base functionality.
+"""
+
+import pytest
+
+
+class TestOpenAICustomApiBase:
+    """Test OpenAI provider with custom api_base."""
+
+    def test_openai_provider_accepts_api_base(self):
+        """Test that OpenAIProvider accepts api_base parameter."""
+        from llms.providers.openai import OpenAIProvider
+
+        # Should not raise an error
+        provider = OpenAIProvider(
+            api_key="test-key",
+            model="gpt-4o",
+            api_base="https://custom.openai.com/v1"
+        )
+        assert provider.model == "gpt-4o"
+        assert provider.client.base_url.host == "custom.openai.com"
+
+    def test_openai_provider_default_base_url(self):
+        """Test that OpenAIProvider uses default base URL when api_base not set."""
+        from llms.providers.openai import OpenAIProvider
+
+        provider = OpenAIProvider(api_key="test-key", model="gpt-4o")
+        assert "openai.com" in str(provider.client.base_url)
+
+
+class TestDeepSeekCustomApiBase:
+    """Test DeepSeek provider with custom api_base."""
+
+    def test_deepseek_provider_accepts_api_base(self):
+        """Test that DeepSeekProvider accepts api_base parameter."""
+        from llms.providers.deepseek import DeepSeekProvider
+
+        provider = DeepSeekProvider(
+            api_key="test-key",
+            model="deepseek-chat",
+            api_base="https://custom.deepseek.com/v1"
+        )
+        assert provider.model == "deepseek-chat"
+        assert provider.client.base_url.host == "custom.deepseek.com"
+
+    def test_deepseek_provider_default_base_url(self):
+        """Test that DeepSeekProvider uses default base URL when api_base not set."""
+        from llms.providers.deepseek import DeepSeekProvider
+
+        provider = DeepSeekProvider(api_key="test-key", model="deepseek-chat")
+        assert "api.deepseek.com" in str(provider.client.base_url)
+
+
+class TestGroqCustomApiBase:
+    """Test Groq provider with custom api_base."""
+
+    def test_groq_provider_accepts_api_base(self):
+        """Test that GroqProvider accepts api_base parameter."""
+        from llms.providers.groq import GroqProvider
+
+        provider = GroqProvider(
+            api_key="test-key",
+            model="llama-3.1-8b-instant",
+            api_base="https://custom.groq.com/v1"
+        )
+        assert provider.model == "llama-3.1-8b-instant"
+        assert provider.client.base_url.host == "custom.groq.com"
+
+    def test_groq_provider_default_base_url(self):
+        """Test that GroqProvider uses default base URL when api_base not set."""
+        from llms.providers.groq import GroqProvider
+
+        provider = GroqProvider(api_key="test-key", model="llama-3.1-8b-instant")
+        assert "api.groq.com" in str(provider.client.base_url)
+
+
+class TestOpenRouterCustomApiBase:
+    """Test OpenRouter provider with custom api_base."""
+
+    def test_openrouter_provider_accepts_api_base(self):
+        """Test that OpenRouterProvider accepts api_base parameter."""
+        from llms.providers.openrouter import OpenRouterProvider
+
+        provider = OpenRouterProvider(
+            api_key="test-key",
+            model="nvidia/llama-3.1-nemotron-70b-instruct",
+            api_base="https://custom.openrouter.ai/v1"
+        )
+        assert provider.model == "nvidia/llama-3.1-nemotron-70b-instruct"
+        assert provider.client.base_url.host == "custom.openrouter.ai"
+
+    def test_openrouter_provider_default_base_url(self):
+        """Test that OpenRouterProvider uses default base URL when api_base not set."""
+        from llms.providers.openrouter import OpenRouterProvider
+
+        provider = OpenRouterProvider(
+            api_key="test-key",
+            model="nvidia/llama-3.1-nemotron-70b-instruct"
+        )
+        assert "openrouter.ai" in str(provider.client.base_url)


### PR DESCRIPTION
## Summary
- Added `api_base` parameter to OpenAI-compatible providers
- Supports: OpenAIProvider, DeepSeekProvider, GroqProvider, OpenRouterProvider
- Allows configuring custom API endpoints via `llms.init()`

## Usage
```python
import llms

# Use custom OpenAI-compatible endpoint
model = llms.init('gpt-4o', api_base='https://your-proxy.com/v1')
```

## Test plan
- [x] Added tests/test_custom_api_base.py
- [x] Verified syntax correctness

Closes #10