### PR TITLE
feat: add context caching support for Anthropic and Google providers

### DIFF
--- a/tests/test_context_caching.py
+++ b/tests/test_context_caching.py
@@ -1,0 +1,154 @@
+"""Tests for context caching functionality in Anthropic and Google providers."""
+
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+import sys
+
+
+class TestAnthropicContextCaching:
+    """Test Anthropic provider context caching."""
+
+    def test_cache_system_message(self):
+        """Test that cache_system properly formats system message."""
+        # Clear module cache to ensure fresh import
+        modules_to_remove = [k for k in sys.modules.keys() if k.startswith('llms')]
+        for mod in modules_to_remove:
+            del sys.modules[mod]
+
+        with patch.dict('sys.modules', {'anthropic': MagicMock()}):
+            from llms.providers.anthropic import AnthropicProvider
+
+            provider = AnthropicProvider(api_key="test-key")
+            model_inputs = provider._prepare_message_inputs(
+                prompt="Hello",
+                system_message="You are a helpful assistant.",
+                cache_system=True,
+            )
+
+            # System should be formatted as list with cache_control
+            assert isinstance(model_inputs["system"], list)
+            assert len(model_inputs["system"]) == 1
+            assert model_inputs["system"][0]["type"] == "text"
+            assert model_inputs["system"][0]["text"] == "You are a helpful assistant."
+            assert model_inputs["system"][0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_cache_messages(self):
+        """Test that cache_messages properly formats the last message."""
+        modules_to_remove = [k for k in sys.modules.keys() if k.startswith('llms')]
+        for mod in modules_to_remove:
+            del sys.modules[mod]
+
+        with patch.dict('sys.modules', {'anthropic': MagicMock()}):
+            from llms.providers.anthropic import AnthropicProvider
+
+            provider = AnthropicProvider(api_key="test-key")
+            model_inputs = provider._prepare_message_inputs(
+                prompt="What is the summary?",
+                cache_messages=True,
+            )
+
+            # Last message should have cache_control
+            last_msg = model_inputs["messages"][-1]
+            assert isinstance(last_msg["content"], list)
+            assert last_msg["content"][0]["type"] == "text"
+            assert last_msg["content"][0]["cache_control"] == {"type": "ephemeral"}
+
+    def test_no_cache_by_default(self):
+        """Test that caching is disabled by default."""
+        modules_to_remove = [k for k in sys.modules.keys() if k.startswith('llms')]
+        for mod in modules_to_remove:
+            del sys.modules[mod]
+
+        with patch.dict('sys.modules', {'anthropic': MagicMock()}):
+            from llms.providers.anthropic import AnthropicProvider
+
+            provider = AnthropicProvider(api_key="test-key")
+            model_inputs = provider._prepare_message_inputs(
+                prompt="Hello",
+                system_message="You are a helpful assistant.",
+            )
+
+            # System should be a plain string
+            assert isinstance(model_inputs["system"], str)
+            # Messages should have string content
+            assert isinstance(model_inputs["messages"][-1]["content"], str)
+
+    def test_cache_metadata_extraction(self):
+        """Test that cache metadata is properly extracted when available."""
+        # This test verifies the metadata extraction logic directly
+        modules_to_remove = [k for k in sys.modules.keys() if k.startswith('llms')]
+        for mod in modules_to_remove:
+            del sys.modules[mod]
+
+        # Create a mock usage object
+        class MockUsage:
+            input_tokens = 100
+            output_tokens = 50
+            cache_creation_input_tokens = 80
+            cache_read_input_tokens = 0
+
+        usage = MockUsage()
+        meta = {}
+
+        # Simulate the metadata extraction logic from complete()
+        if hasattr(usage, "cache_creation_input_tokens"):
+            meta["cache_creation_input_tokens"] = usage.cache_creation_input_tokens
+        if hasattr(usage, "cache_read_input_tokens"):
+            meta["cache_read_input_tokens"] = usage.cache_read_input_tokens
+
+        assert meta["cache_creation_input_tokens"] == 80
+        assert meta["cache_read_input_tokens"] == 0
+
+
+class TestGoogleContextCaching:
+    """Test Google GenAI provider context caching."""
+
+    def test_cached_content_parameter(self):
+        """Test that cached_content is passed through to config."""
+        with patch('llms.providers.google_genai.genai') as mock_genai:
+            from llms.providers.google_genai import GoogleGenAIProvider
+
+            mock_genai.Client.return_value = Mock()
+
+            provider = GoogleGenAIProvider(api_key="test-key")
+            model_inputs = provider._prepare_model_inputs(
+                prompt="Test prompt",
+                cached_content="caches/abc123",
+            )
+
+            assert model_inputs["cached_content"] == "caches/abc123"
+
+    def test_create_cache_method(self):
+        """Test the create_cache helper method."""
+        with patch('llms.providers.google_genai.genai') as mock_genai:
+            from llms.providers.google_genai import GoogleGenAIProvider
+
+            mock_client = Mock()
+            mock_cache = Mock()
+            mock_cache.name = "caches/test-cache-123"
+            mock_client.caches.create.return_value = mock_cache
+            mock_genai.Client.return_value = mock_client
+
+            provider = GoogleGenAIProvider(api_key="test-key")
+            cache_name = provider.create_cache(
+                contents="Long document content...",
+                system_instruction="You are an expert.",
+                ttl="7200s",
+                display_name="My Cache"
+            )
+
+            assert cache_name == "caches/test-cache-123"
+            mock_client.caches.create.assert_called_once()
+
+    def test_delete_cache_method(self):
+        """Test the delete_cache helper method."""
+        with patch('llms.providers.google_genai.genai') as mock_genai:
+            from llms.providers.google_genai import GoogleGenAIProvider
+
+            mock_client = Mock()
+            mock_genai.Client.return_value = mock_client
+
+            provider = GoogleGenAIProvider(api_key="test-key")
+            provider.delete_cache("caches/test-cache-123")
+
+            mock_client.caches.delete.assert_called_once_with(name="caches/test-cache-123")

--- a/tests/test_huggingface_provider.py
+++ b/tests/test_huggingface_provider.py
@@ -1,0 +1,94 @@
+"""Tests for HuggingFace Hub Provider using InferenceClient."""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from llms.providers.huggingface import HuggingfaceHubProvider
+
+
+class TestHuggingfaceProviderInit:
+    """Test HuggingfaceHubProvider initialization."""
+
+    def test_default_model(self):
+        """Test that default model is set correctly."""
+        with patch('llms.providers.huggingface.InferenceClient'):
+            provider = HuggingfaceHubProvider(api_key="test-key")
+            assert provider.model == "hf_pythia"
+            assert provider._model_full_name == "OpenAssistant/oasst-sft-4-pythia-12b-epoch-3.5"
+
+    def test_custom_model(self):
+        """Test initialization with custom model."""
+        with patch('llms.providers.huggingface.InferenceClient'):
+            provider = HuggingfaceHubProvider(api_key="test-key", model="hf_falcon7b")
+            assert provider.model == "hf_falcon7b"
+            assert provider._model_full_name == "tiiuae/falcon-7b-instruct"
+
+    def test_inference_client_created(self):
+        """Test that InferenceClient is created with token."""
+        with patch('llms.providers.huggingface.InferenceClient') as mock_client:
+            provider = HuggingfaceHubProvider(api_key="test-api-key")
+            mock_client.assert_called_once_with(token="test-api-key")
+
+
+class TestHuggingfaceProviderComplete:
+    """Test HuggingfaceHubProvider complete method."""
+
+    def test_complete_calls_text_generation(self):
+        """Test that complete uses text_generation API."""
+        with patch('llms.providers.huggingface.InferenceClient') as mock_client_class:
+            mock_client = Mock()
+            # For hf_pythia, the prompt is formatted with special tokens
+            formatted_prompt = "<|prompter|Test prompt.<|endoftext|><|assistant|>"
+            mock_client.text_generation.return_value = formatted_prompt + " This is the response."
+            mock_client_class.return_value = mock_client
+
+            provider = HuggingfaceHubProvider(api_key="test-key")
+            result = provider.complete("Test prompt.", max_tokens=100)
+
+            mock_client.text_generation.assert_called_once()
+            call_kwargs = mock_client.text_generation.call_args
+            # hf_pythia model wraps prompt with special tokens
+            assert "<|prompter|" in call_kwargs[0][0]
+            assert call_kwargs[1]["model"] == "OpenAssistant/oasst-sft-4-pythia-12b-epoch-3.5"
+            assert call_kwargs[1]["return_full_text"] is True
+
+    def test_complete_with_falcon_model(self):
+        """Test complete with a model that doesn't modify prompt."""
+        with patch('llms.providers.huggingface.InferenceClient') as mock_client_class:
+            mock_client = Mock()
+            mock_client.text_generation.return_value = "Hello world. This is a response."
+            mock_client_class.return_value = mock_client
+
+            provider = HuggingfaceHubProvider(api_key="test-key", model="hf_falcon7b")
+            result = provider.complete("Hello world.", max_tokens=100)
+
+            call_kwargs = mock_client.text_generation.call_args
+            assert call_kwargs[0][0] == "Hello world."
+            assert call_kwargs[1]["model"] == "tiiuae/falcon-7b-instruct"
+
+    def test_complete_returns_result(self):
+        """Test that complete returns a valid Result object."""
+        with patch('llms.providers.huggingface.InferenceClient') as mock_client_class:
+            mock_client = Mock()
+            mock_client.text_generation.return_value = "Hello world. This is a response."
+            mock_client_class.return_value = mock_client
+
+            provider = HuggingfaceHubProvider(api_key="test-key", model="hf_falcon7b")
+            result = provider.complete("Hello world.")
+
+            assert result.text == " This is a response."
+            assert result.meta["tokens_prompt"] == -1
+            assert result.meta["tokens_completion"] == -1
+            assert "latency" in result.meta
+
+
+class TestHuggingfaceModelInfo:
+    """Test MODEL_INFO structure."""
+
+    def test_all_models_have_required_fields(self):
+        """Test that all models have required pricing fields."""
+        for model_name, model_info in HuggingfaceHubProvider.MODEL_INFO.items():
+            assert "full" in model_info, f"{model_name} missing 'full' name"
+            assert "prompt" in model_info, f"{model_name} missing 'prompt' price"
+            assert "completion" in model_info, f"{model_name} missing 'completion' price"
+            assert "token_limit" in model_info, f"{model_name} missing 'token_limit'"


### PR DESCRIPTION
## Summary
Implements context caching (Issue #25) for Anthropic and Google providers:

**Anthropic:**
- `cache_system`: Cache system messages with `cache_control: {"type": "ephemeral"}`
- `cache_messages`: Cache the last message content
- Returns `cache_creation_input_tokens` and `cache_read_input_tokens` in response metadata

**Google GenAI:**
- `cached_content`: Pass a pre-created cache name to use context caching
- `create_cache()`: Helper method to create context caches
- `delete_cache()`: Helper method to clean up caches

## Usage Example

```python
# Anthropic - cache system message
result = llm.complete(
    "Summarize the document",
    system_message="You are an expert analyst. Here is a long document...",
    cache_system=True
)

# Google - create and use cache
cache_name = provider.create_cache(
    contents="Very long document...",
    system_instruction="You are an expert.",
    ttl="7200s"
)
result = llm.complete("Question about the doc", cached_content=cache_name)
```

## Test plan
- [x] Unit tests for Anthropic cache_system and cache_messages
- [x] Unit tests for Google cached_content, create_cache, delete_cache
- [x] All existing tests pass

Closes #25